### PR TITLE
Add JavaScript example to request data from REST API

### DIFF
--- a/src/requestData.js
+++ b/src/requestData.js
@@ -1,0 +1,11 @@
+const axios = require('axios');
+
+const url = 'https://api.energidataservice.dk/dataset/RegulatingBalancePowerdata?limit=5';
+
+axios.get(url)
+  .then(response => {
+    console.log(response.data);
+  })
+  .catch(error => {
+    console.error('Error fetching data:', error);
+  });


### PR DESCRIPTION
Add a JavaScript Node.js example to request data from a REST API endpoint.

* Create a new file `src/requestData.js`.
* Use the `axios` library to make a GET request to 'https://api.energidataservice.dk/dataset/RegulatingBalancePowerdata?limit=5'.
* Log the response data to the console.
* Handle and log any errors that occur during the request.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jalalhejazi/devbox-pwsh/pull/2?shareId=8120fdff-6cbb-45de-a1c1-08a08bf6b1f5).